### PR TITLE
Add support for capturing matches

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,6 +235,43 @@ extglob.create = function(pattern, options) {
 };
 
 /**
+ * Returns an array of matches captured by `pattern` in `string, or `null` if the pattern did not match.
+ *
+ * ```js
+ * var extglob = require('extglob');
+ * extglob.capture(pattern, string[, options]);
+ *
+ * console.log(extglob.capture('test/*.js', 'test/foo.js));
+ * //=> ['foo']
+ * console.log(extglob.capture('test/*.js', 'foo/bar.css'));
+ * //=> null
+ * ```
+ * @param {String} `pattern` Glob pattern to use for matching.
+ * @param {String} `string` String to match
+ * @param {Object} `options` See available [options](#options) for changing how matches are performed
+ * @return {Boolean} Returns an array of captures if the string matches the glob pattern, otherwise `null`.
+ * @api public
+ */
+
+extglob.capture = function(pattern, str, options) {
+  var re = extglob.makeRe(pattern, extend({capture: true}, options));
+
+  function match() {
+    return function(string) {
+      var match = re.exec(string);
+      if (!match) {
+        return null;
+      }
+
+      return match.slice(1);
+    };
+  }
+
+  var capture = utils.memoize('capture', pattern, options, match);
+  return capture(str);
+};
+
+/**
  * Create a regular expression from the given `pattern` and `options`.
  *
  * ```js

--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -106,22 +106,32 @@ module.exports = function(extglob) {
       return this.mapVisit(node.nodes);
     })
     .set('paren.open', function(node) {
+      var capture = this.options.capture ? '(' : '';
+
       switch (node.parent.prefix) {
         case '!':
         case '^':
-          return this.emit('(?:(?!(?:', node);
+          return this.emit(capture + '(?:(?!(?:', node);
         case '*':
         case '+':
         case '?':
         case '@':
-          return this.emit('(', node);
+          return this.emit(capture + '(?:', node);
         default: {
-          var val = (this.options.bash === true ? '\\' : '') + node.val;
+          var val = node.val;
+          if (this.options.bash === true) {
+            val = '\\' + val;
+          } else if (!this.options.capture && val === '(' && node.parent.rest[0] !== '?') {
+            val += '?:';
+          }
+
           return this.emit(val, node);
         }
       }
     })
     .set('paren.close', function(node) {
+      var capture = this.options.capture ? ')' : '';
+
       switch (node.prefix) {
         case '!':
         case '^':
@@ -134,15 +144,13 @@ module.exports = function(extglob) {
             str = '.*?';
           }
 
-          return this.emit(prefix + ('))' + str + ')'), node);
-        case '+':
-          return this.emit(')+', node);
+          return this.emit(prefix + ('))' + str + ')') + capture, node);
         case '*':
-          return this.emit(')*', node);
+        case '+':
         case '?':
-          return this.emit(')?', node);
+          return this.emit(')' + node.prefix + capture, node);
         case '@':
-          return this.emit(')', node);
+          return this.emit(')' + capture, node);
         default: {
           var val = (this.options.bash === true ? '\\' : '') + ')';
           return this.emit(val, node);

--- a/test/capture.js
+++ b/test/capture.js
@@ -1,0 +1,43 @@
+var capture = require('../').capture;
+var assert = require('assert');
+
+describe('.capture()', function() {
+  it('should return null if no match', function() {
+    assert.equal(capture('test/(a|b)', 'hi/123'), null);
+  });
+
+  it('should capture paren groups', function() {
+    assert.deepEqual(capture('test/(a|b)/x.js', 'test/a/x.js'), ['a']);
+    assert.deepEqual(capture('test/(a|b)/x.js', 'test/b/x.js'), ['b']);
+  });
+
+  it('should capture star groups', function() {
+    assert.deepEqual(capture('test/a*(a|b)/x.js', 'test/a/x.js'), ['']);
+    assert.deepEqual(capture('test/a*(a|b)/x.js', 'test/aa/x.js'), ['a']);
+    assert.deepEqual(capture('test/a*(a|b)/x.js', 'test/ab/x.js'), ['b']);
+    assert.deepEqual(capture('test/a*(a|b)/x.js', 'test/aba/x.js'), ['ba']);
+  });
+
+  it('should capture plus groups', function() {
+    assert.deepEqual(capture('test/+(a|b)/x.js', 'test/a/x.js'), ['a']);
+    assert.deepEqual(capture('test/+(a|b)/x.js', 'test/b/x.js'), ['b']);
+    assert.deepEqual(capture('test/+(a|b)/x.js', 'test/ab/x.js'), ['ab']);
+    assert.deepEqual(capture('test/+(a|b)/x.js', 'test/aba/x.js'), ['aba']);
+  });
+
+  it('should capture optional groups', function() {
+    assert.deepEqual(capture('test/a?(a|b)/x.js', 'test/a/x.js'), ['']);
+    assert.deepEqual(capture('test/a?(a|b)/x.js', 'test/ab/x.js'), ['b']);
+    assert.deepEqual(capture('test/a?(a|b)/x.js', 'test/aa/x.js'), ['a']);
+  });
+
+  it('should capture @ groups', function() {
+    assert.deepEqual(capture('test/@(a|b)/x.js', 'test/a/x.js'), ['a']);
+    assert.deepEqual(capture('test/@(a|b)/x.js', 'test/b/x.js'), ['b']);
+  });
+
+  it('should capture negated groups', function() {
+    assert.deepEqual(capture('test/!(a|b)/x.js', 'test/x/x.js'), ['x']);
+    assert.deepEqual(capture('test/!(a|b)/x.js', 'test/y/x.js'), ['y']);
+  });
+});


### PR DESCRIPTION
Adds `extglob.capture`, similar to `nanomatch.capture` from https://github.com/micromatch/nanomatch/pull/4.

This changes regex generation in normal (non-capturing) mode so that parens generate non-capturing groups (e.g. `(?:abc)*`). In capturing mode, an additional set of parentheses is added to capture the full output (e.g. `((?:abc)*)`).